### PR TITLE
Fix mistake in uploaded audio on Android

### DIFF
--- a/inconsistencies-media/attachments-non-conformant.md
+++ b/inconsistencies-media/attachments-non-conformant.md
@@ -27,7 +27,7 @@ The parameters are identical to those of a [standard attachment reference](attac
 {% tabs %}
 {% tab title="Android" %}
 ```text
-AUD-20190101-WA0000.
+AUD-20190101-WA0000. (file attached)
 ```
 {% endtab %}
 {% endtabs %}


### PR DESCRIPTION
The example for non-conformant attachments had a mistake, the latter part of the string was missing.